### PR TITLE
Use github actions to deploy website

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -20,6 +20,7 @@ jobs:
   deploy:
     # Add a dependency to the build job
     needs: build
+    if: github.ref == 'refs/heads/master' # Only deploys on master
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:


### PR DESCRIPTION
Benefits:
- No longer tied to whatever plugins and versions decides to allow. https://pages.github.com/versions/
- Can add additional, non-jekyll build steps.

Negatives:
- Another thing to tinker with.